### PR TITLE
feat(driver): add parallel_lights_io driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,5 @@ set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(libs/hidapi)
 add_subdirectory(libs/unilight)
 add_subdirectory(driver_pacdrive)
+add_subdirectory(driver_parallel_lights_io)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(lightDrivers VERSION 0.2)
+project(lightDrivers VERSION 0.3)
 
 # Link hidapi statically
 set(BUILD_SHARED_LIBS OFF)

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ with Stepmania/OpenITG/ITGMania enabling support of BlueDot light boards.</p>
 |------------|-------------|--------|
 | [BlueDot Unilight] | Driving DDR cabinet lights through USB. | Supported |
 
-### Supported games
+### Supported games and platforms
 
-| Game name | Platform | Status | Driver |
-|-----------|----------|--------|--------|
-| [Stepmania] | All | Unsupported | - |
-| [OpenITG] | All | Unsupported | - |
-| [ITGMania] | Win64 | Supported | pacdrive64.dll |
-| [ITGMania] | Linux | Unsupported | - |
-| [ITGMania] | MacOS | Unsupported | - |
+The following table lists the supported combinations of games and platforms and the corresponding suggested
+driver to use:
+
+| Game        | Platform | Driver                 |
+|-------------|----------|------------------------|
+| [Stepmania] | Win32    | parallel_lights_io.dll |
+| [OpenITG]   | Win32    | parallel_lights_io.dll |
+| [ITGMania]  | Win64    | pacdrive64.dll         |
 
 ## Compile from source
 

--- a/driver_parallel_lights_io/CMakeLists.txt
+++ b/driver_parallel_lights_io/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.15)
+project(parallel_lights_io)
+
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+
+add_library(parallel_lights_io SHARED ${SOURCES})
+
+target_include_directories(parallel_lights_io PUBLIC include)
+target_link_libraries(parallel_lights_io PRIVATE unilight)
+
+set_target_properties(parallel_lights_io PROPERTIES OUTPUT_NAME "parallel_lights_io")
+set_target_properties(parallel_lights_io PROPERTIES PREFIX "")
+
+# Generate test executable
+
+file(GLOB_RECURSE TEST_SOURCES "test/*.cpp")
+add_executable(parallel_lights_io_test ${TEST_SOURCES})
+
+set_target_properties(parallel_lights_io_test PROPERTIES
+    LINK_FLAGS "-static-libgcc -static-libstdc++")
+
+
+

--- a/driver_parallel_lights_io/include/parallel_lights_io.h
+++ b/driver_parallel_lights_io/include/parallel_lights_io.h
@@ -1,0 +1,23 @@
+#ifndef PARALLEL_LIGHTS_IO_H_
+#define PARALLEL_LIGHTS_IO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EXPORT __declspec(dllexport)
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+
+EXPORT BOOLEAN WINAPI DllMain(IN HINSTANCE, IN DWORD, IN LPVOID);
+
+EXPORT void WINAPI PortOut(short int Port, char Data);
+
+EXPORT short int WINAPI IsDriverInstalled();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PARALLEL_LIGHTS_IO_H_

--- a/driver_parallel_lights_io/src/parallel_lights_io.cpp
+++ b/driver_parallel_lights_io/src/parallel_lights_io.cpp
@@ -1,6 +1,10 @@
 #include <parallel_lights_io.h>
 #include <unilight.h>
 
+#define PORT_LPT1 0x378
+#define PORT_LPT2 0x278
+#define PORT_LPT3 0x3BC
+
 #define IS_BIT_SET(data, bit) ((data & (1 << bit)) != 0)
 
 BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason, IN LPVOID Reserved)
@@ -22,41 +26,58 @@ BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason, IN LPVOID Rese
   return TRUE;
 }
 
-/* TODO: Move to PortOut
-bool PacSetLEDStates(int deviceId, short int data) {
-  bool success = true;
-
-  uint8_t pad_lights_state = 0;
-  if(IS_BIT_SET(data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
-  if(IS_BIT_SET(data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
-  if(IS_BIT_SET(data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
-  if(IS_BIT_SET(data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
-  if(IS_BIT_SET(data, 4)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
-  if(IS_BIT_SET(data, 5)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
-  if(IS_BIT_SET(data, 6)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
-  if(IS_BIT_SET(data, 7)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
-  if(bd_unilight_set_pad_lights(pad_lights_state) != 0) {
-    success = false;
-  }
-  
+void SetCabLights(char Data) {
   uint8_t cab_lights_state = 0;
-  if(IS_BIT_SET(data, 8)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_UP_LEFT;
-  if(IS_BIT_SET(data, 9)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_UP_RIGHT;
-  if(IS_BIT_SET(data, 10)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_LR_LEFT;
-  if(IS_BIT_SET(data, 11)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_LR_RIGHT;
-  if(IS_BIT_SET(data, 12)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BUTTONS_P1;
-  if(IS_BIT_SET(data, 13)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BUTTONS_P2;
-  if(IS_BIT_SET(data, 14)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BASS;
+  if(IS_BIT_SET(Data, 0)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_UP_LEFT;
+  if(IS_BIT_SET(Data, 1)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_UP_RIGHT;
+  if(IS_BIT_SET(Data, 2)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_LR_LEFT;
+  if(IS_BIT_SET(Data, 3)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_LR_RIGHT;
+  if(IS_BIT_SET(Data, 4)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BUTTONS_P1;
+  if(IS_BIT_SET(Data, 5)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BUTTONS_P2;
+  if(IS_BIT_SET(Data, 6)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BASS;
+  if(IS_BIT_SET(Data, 7)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BASS;
   if(bd_unilight_set_cab_lights(cab_lights_state) != 0) {
-    success = false;
+    // No error handling in this implementation
   }
-
-  return success;
 }
-*/
+
+void SetPad1Lights(char Data) {
+  uint8_t pad_lights_state = 0;
+  if(IS_BIT_SET(data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
+  if(IS_BIT_SET(data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
+  if(IS_BIT_SET(data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
+  if(IS_BIT_SET(data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
+  if(bd_unilight_set_pad_lights(pad_lights_state) != 0) {
+    // No error handling in this implementation
+  }
+}
+
+void SetPad2Lights(char Data) {
+  uint8_t pad_lights_state = 0;
+  if(IS_BIT_SET(data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_LEFT;
+  if(IS_BIT_SET(data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_RIGHT;
+  if(IS_BIT_SET(data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_UP;
+  if(IS_BIT_SET(data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_DOWN;
+  if(bd_unilight_set_pad_lights(pad_lights_state) != 0) {
+    // No error handling in this implementation
+  }
+}
 
 void PortOut(short int Port, char Data) {
-
+  switch(Port) {
+    case PORT_LPT1:
+      SetCabLights(Data);
+      break;
+    case PORT_LPT2:
+      SetPad1Lights(Data);
+      break;
+    case PORT_LPT3:
+      SetPad2Lights(Data);
+      break;
+    default:
+      // Invalid port
+      break;
+  }
 }
 
 short int IsDriverInstalled() {

--- a/driver_parallel_lights_io/src/parallel_lights_io.cpp
+++ b/driver_parallel_lights_io/src/parallel_lights_io.cpp
@@ -43,10 +43,10 @@ void SetCabLights(char Data) {
 
 void SetPad1Lights(char Data) {
   uint8_t pad_lights_state = 0;
-  if(IS_BIT_SET(data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
-  if(IS_BIT_SET(data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
-  if(IS_BIT_SET(data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
-  if(IS_BIT_SET(data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
+  if(IS_BIT_SET(Data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
+  if(IS_BIT_SET(Data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
+  if(IS_BIT_SET(Data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
+  if(IS_BIT_SET(Data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
   if(bd_unilight_set_pad_lights(pad_lights_state) != 0) {
     // No error handling in this implementation
   }
@@ -54,10 +54,10 @@ void SetPad1Lights(char Data) {
 
 void SetPad2Lights(char Data) {
   uint8_t pad_lights_state = 0;
-  if(IS_BIT_SET(data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_LEFT;
-  if(IS_BIT_SET(data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_RIGHT;
-  if(IS_BIT_SET(data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_UP;
-  if(IS_BIT_SET(data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_DOWN;
+  if(IS_BIT_SET(Data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_LEFT;
+  if(IS_BIT_SET(Data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_RIGHT;
+  if(IS_BIT_SET(Data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_UP;
+  if(IS_BIT_SET(Data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P2_DOWN;
   if(bd_unilight_set_pad_lights(pad_lights_state) != 0) {
     // No error handling in this implementation
   }

--- a/driver_parallel_lights_io/src/parallel_lights_io.cpp
+++ b/driver_parallel_lights_io/src/parallel_lights_io.cpp
@@ -1,0 +1,65 @@
+#include <parallel_lights_io.h>
+#include <unilight.h>
+
+#define IS_BIT_SET(data, bit) ((data & (1 << bit)) != 0)
+
+BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason, IN LPVOID Reserved)
+{
+  switch (nReason) {
+  case DLL_PROCESS_ATTACH:
+    if(!bd_unilight_is_open()) {
+      if(bd_unilight_open() != 0) {
+        return FALSE;
+      }
+    }
+    break;
+  case DLL_PROCESS_DETACH:
+    if(bd_unilight_is_open()) {
+      bd_unilight_close();
+    }
+    break;
+  }
+  return TRUE;
+}
+
+/* TODO: Move to PortOut
+bool PacSetLEDStates(int deviceId, short int data) {
+  bool success = true;
+
+  uint8_t pad_lights_state = 0;
+  if(IS_BIT_SET(data, 0)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
+  if(IS_BIT_SET(data, 1)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
+  if(IS_BIT_SET(data, 2)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
+  if(IS_BIT_SET(data, 3)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
+  if(IS_BIT_SET(data, 4)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_UP;
+  if(IS_BIT_SET(data, 5)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_DOWN;
+  if(IS_BIT_SET(data, 6)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_LEFT;
+  if(IS_BIT_SET(data, 7)) pad_lights_state |= BD_UNILIGHT_LIGHT_PAD_P1_RIGHT;
+  if(bd_unilight_set_pad_lights(pad_lights_state) != 0) {
+    success = false;
+  }
+  
+  uint8_t cab_lights_state = 0;
+  if(IS_BIT_SET(data, 8)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_UP_LEFT;
+  if(IS_BIT_SET(data, 9)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_UP_RIGHT;
+  if(IS_BIT_SET(data, 10)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_LR_LEFT;
+  if(IS_BIT_SET(data, 11)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_MARQUEE_LR_RIGHT;
+  if(IS_BIT_SET(data, 12)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BUTTONS_P1;
+  if(IS_BIT_SET(data, 13)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BUTTONS_P2;
+  if(IS_BIT_SET(data, 14)) cab_lights_state |= BD_UNILIGHT_LIGHT_CAB_BASS;
+  if(bd_unilight_set_cab_lights(cab_lights_state) != 0) {
+    success = false;
+  }
+
+  return success;
+}
+*/
+
+void PortOut(short int Port, char Data) {
+
+}
+
+short int IsDriverInstalled() {
+  return true;
+}
+

--- a/driver_parallel_lights_io/test/test_parallel_lights_io.cpp
+++ b/driver_parallel_lights_io/test/test_parallel_lights_io.cpp
@@ -1,0 +1,8 @@
+#include <windows.h>
+#include <iostream>
+
+// TODO
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
This PR adds the parallel_lights_io driver implementation which generates the `parallel_lights_io.dll ` on win32 platforms.

The following games/platforms are now supported:

- [x] OpenITG / Win32
- [x] Stepmania / Win32

Other games may be supported if `parallel_lights_io.dll` is used.